### PR TITLE
Add rust-toolchain.toml

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "stable"
+profile = "default"


### PR DESCRIPTION
This will let cargo (via rustup) auto-configure itself appropriately.