### PR TITLE
fix: verify that outputs were created

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,4 +23,5 @@ jobs:
       - uses: cashapp/activate-hermit@v1
         with:
           cache: true
+      - run: cargo build
       - run: cargo test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,10 +12,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstyle"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+
+[[package]]
+name = "assert_cmd"
+version = "2.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1835b7f27878de8525dc71410b5a31cdcc5f230aed5ba5df968e09c201b23d"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "doc-comment",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+
+[[package]]
+name = "bstr"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a68f1f47cdf0ec8ee4b941b2eee2a80cb796db73118c0dd09ac63fbe405be22"
+dependencies = [
+ "memchr",
+ "regex-automata 0.4.6",
+ "serde",
+]
 
 [[package]]
 name = "cfg-if"
@@ -31,6 +64,18 @@ checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
 ]
+
+[[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "errno"
@@ -91,6 +136,7 @@ checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 name = "mk"
 version = "0.1.0"
 dependencies = [
+ "assert_cmd",
  "shell-words",
  "tempfile",
  "time",
@@ -139,6 +185,33 @@ name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "predicates"
+version = "3.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e9086cc7640c29a356d1a29fd134380bee9d8f79a17410aa76e7ad295f42c97"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae8177bee8e75d6846599c6b9ff679ed51e882816914eec639944d7c9aa11931"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41b740d195ed3166cd147c8047ec98db0e22ec019eb8eeb76d343b795304fb13"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -290,6 +363,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "termtree"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
+
+[[package]]
 name = "thread_local"
 version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -411,6 +490,15 @@ name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,6 @@ tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 walkdir = "2.5.0"
 
 [dev-dependencies]
+assert_cmd = "2.0.16"
 tempfile = "3.10.1"
 tracing-test = "0.2.4"

--- a/bin/hermit.hcl
+++ b/bin/hermit.hcl
@@ -1,0 +1,6 @@
+env = {
+  "PATH": "${HERMIT_ENV}/scripts:${PATH}",
+}
+
+github-token-auth {
+}

--- a/scripts/mk
+++ b/scripts/mk
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec cargo run -q -- "$@"

--- a/src/main_test.rs
+++ b/src/main_test.rs
@@ -1,0 +1,119 @@
+use assert_cmd::Command;
+use tempfile::{tempdir, TempDir};
+
+#[test]
+fn test_mk_ok() {
+    let tmpdir = tempdir().unwrap();
+    touch(&tmpdir, "input");
+    assert_mk_ok(&tmpdir, &["output", ":", "input", "--", "touch", "output"]);
+    assert_exists(&tmpdir, "output");
+}
+
+#[test]
+fn test_mk_no_rebuild() {
+    let tmpdir = tempdir().unwrap();
+    touch(&tmpdir, "input");
+    touch(&tmpdir, "output");
+    assert_mk_ok(&tmpdir, &["output", ":", "input", "--", "false"]);
+    assert_exists(&tmpdir, "output");
+}
+
+#[test]
+fn test_mk_command_fails() {
+    let tmpdir = tempdir().unwrap();
+    touch(&tmpdir, "input");
+    assert_mk_fails(&tmpdir, &["output", ":", "input", "--", "false"]);
+    assert_not_exists(&tmpdir, "output");
+}
+
+#[test]
+fn test_mk_missing_input() {
+    let tmpdir = tempdir().unwrap();
+    assert_mk_fails(&tmpdir, &["output", ":", "input", "--", "touch", "output"]);
+    assert_not_exists(&tmpdir, "output");
+}
+
+#[test]
+fn test_mk_missing_output() {
+    let tmpdir = tempdir().unwrap();
+    assert_mk_fails(&tmpdir, &["output", ":", "input", "--", "true"]);
+    assert_not_exists(&tmpdir, "output");
+}
+
+#[test]
+fn test_unknown_command() {
+    let tmpdir = tempdir().unwrap();
+    touch(&tmpdir, "input");
+    assert_mk_fails(
+        &tmpdir,
+        &["output", ":", "input", "--", "thereisdefinitelynocommand"],
+    );
+    assert_not_exists(&tmpdir, "output");
+}
+
+#[test]
+fn test_mk_output_with_no_input() {
+    let tmpdir = tempdir().unwrap();
+    assert_mk_ok(&tmpdir, &["output", "--", "touch", "output"]);
+    assert_exists(&tmpdir, "output");
+}
+
+#[test]
+fn test_mk_output_with_no_input_or_command() {
+    let tmpdir = tempdir().unwrap();
+    assert_mk_fails(&tmpdir, &["output"]);
+    assert_not_exists(&tmpdir, "output");
+}
+
+#[test]
+fn test_mk_no_input_never_rebuilds() {
+    let tmpdir = tempdir().unwrap();
+    assert_mk_ok(&tmpdir, &["output", "--", "touch", "output"]);
+    assert_exists(&tmpdir, "output");
+    let old_time = file_time(&tmpdir, "output");
+    assert_mk_ok(&tmpdir, &["output", "--", "touch", "output"]);
+    let new_time = file_time(&tmpdir, "output");
+    assert_eq!(old_time, new_time);
+}
+
+#[track_caller]
+fn assert_mk_ok(tmpdir: &TempDir, args: &[&str]) {
+    let mut cmd = Command::cargo_bin("mk").unwrap();
+    cmd.current_dir(tmpdir);
+    cmd.args(args);
+    cmd.assert().success();
+}
+
+#[track_caller]
+fn assert_mk_fails(tmpdir: &TempDir, args: &[&str]) {
+    let mut cmd = Command::cargo_bin("mk").unwrap();
+    cmd.current_dir(tmpdir);
+    cmd.args(args);
+    let assert = cmd.assert().failure();
+    println!("{:?}", assert.get_output());
+}
+
+#[track_caller]
+fn assert_exists(tmpdir: &TempDir, path: &str) {
+    let path = tmpdir.path().join(path);
+    assert!(path.exists());
+}
+
+#[track_caller]
+fn assert_not_exists(tmpdir: &TempDir, path: &str) {
+    let path = tmpdir.path().join(path);
+    assert!(!path.exists());
+}
+
+#[track_caller]
+fn touch(tmpdir: &TempDir, path: &str) {
+    std::fs::File::create_new(tmpdir.path().join(path))
+        .unwrap()
+        .set_modified(std::time::SystemTime::now())
+        .unwrap();
+}
+
+fn file_time(tmpdir: &TempDir, path: &str) -> std::time::SystemTime {
+    let path = tmpdir.path().join(path);
+    std::fs::metadata(path).unwrap().modified().unwrap()
+}

--- a/src/target.rs
+++ b/src/target.rs
@@ -1,3 +1,4 @@
+use std::io::ErrorKind;
 use std::path::PathBuf;
 use std::time::SystemTime;
 
@@ -7,6 +8,7 @@ use tracing::{debug, info, trace};
 use walkdir::WalkDir;
 
 pub struct Target {
+    outputs: Vec<String>,
     command: Vec<String>,
     pub needs_rebuild: bool,
 }
@@ -14,84 +16,99 @@ pub struct Target {
 impl Target {
     // Parse the arguments into a Target struct.
     pub fn parse(args: Vec<String>) -> Result<Target, Error> {
-        enum State {
-            Output,
-            Input,
-            Command,
-        }
-
-        use State::*;
-
         // Option<File>
         let mut newest_output = File::default();
-        let mut command = Vec::<String>::new();
-        let mut state = Output;
-        let mut have_inputs = false;
         let mut needs_rebuild = false;
+        let mut outputs = Vec::new();
+        let mut inputs = Vec::new();
+        let mut command = Vec::new();
 
+        let mut current_vec = &mut outputs;
         for arg in args {
-            match (&state, arg.as_str()) {
-                (Output, ":") => state = Input,
-                (Output, _) => {
-                    let newest = match find_newest(&arg) {
-                        Err(e) if e.is_not_found() => {
-                            info!("output {} does not exist", arg);
-                            needs_rebuild = true;
-                            continue;
-                        }
-                        Err(e) => return Err(e),
-                        Ok(n) => n,
-                    };
-                    if newest > newest_output {
-                        debug!("{} is the newest output", newest);
-                        newest_output = newest
-                    }
-                }
-                (Input, "--") => state = Command,
-                (Input, _) => {
-                    if needs_rebuild {
-                        continue;
-                    }
-                    have_inputs = true;
-                    let newest = find_newest(&arg)?;
-                    if newest > newest_output {
-                        debug!(
-                            "input {} is newer than output {}, rebuilding",
-                            newest, newest_output
-                        );
-                        needs_rebuild = true;
-                    } else {
-                        trace!(
-                            "input {} is not newer than newest output {}",
-                            newest,
-                            newest_output
-                        )
-                    }
-                }
-                (Command, _) => command.push(arg),
+            match arg.as_str() {
+                ":" => current_vec = &mut inputs,
+                "--" => current_vec = &mut command,
+                _ => current_vec.push(arg),
             }
         }
+
+        // Find latest output
+        for output in outputs.iter() {
+            let newest = match find_newest(output) {
+                Err(e) if e.is_not_found() => {
+                    info!("output {} does not exist", output);
+                    needs_rebuild = true;
+                    continue;
+                }
+                Err(e) => return Err(e),
+                Ok(n) => n,
+            };
+            if newest > newest_output {
+                debug!("{} is the newest output", newest);
+                newest_output = newest
+            }
+        }
+
+        if !needs_rebuild {
+            return Ok(Target {
+                outputs,
+                command,
+                needs_rebuild,
+            });
+        }
+
+        for input in inputs.iter() {
+            let newest = match find_newest(input) {
+                Ok(n) => n,
+                Err(e) if e.is_not_found() => {
+                    return Err(Error::MissingInput(input.clone()));
+                }
+                Err(e) => return Err(e),
+            };
+            if newest > newest_output {
+                debug!(
+                    "input {} is newer than output {}, rebuilding",
+                    newest, newest_output
+                );
+                needs_rebuild = true;
+                break;
+            } else {
+                trace!(
+                    "input {} is older than newest output {}",
+                    newest,
+                    newest_output
+                )
+            }
+        }
+
         // Always rebuild if no inputs are provided.
-        if !have_inputs && !needs_rebuild {
+        if inputs.is_empty() && !needs_rebuild {
             trace!("no inputs provided, forcing rebuild");
             needs_rebuild = true;
         }
         if newest_output == File::default() {
             info!("no outputs found");
+            if command.is_empty() {
+                return Err(Error::MissingOutput(outputs[0].clone()));
+            }
         } else {
             info!("newest output is {}", newest_output);
         }
         Ok(Target {
+            outputs,
             command,
             needs_rebuild,
         })
     }
 
+    /// Returns true if the command should be run.
     pub fn should_run_command(&self) -> bool {
         self.needs_rebuild && !self.command.is_empty()
     }
 
-    pub fn run_command(&self) -> Result<i32, Error> {
+    // Run the command and verify that all outputs exist.
+    // Will not display the command if it is prefixed with `@`.
+    pub fn run_command(&self) -> Result<(), Error> {
         let mut shell_command = if self.command.len() > 1 {
             shell_words::join(&self.command)
         } else {
@@ -103,11 +120,24 @@ impl Target {
         } else {
             println!("{}", &shell_command);
         }
-        Ok(std::process::Command::new("bash")
+        let status = std::process::Command::new("bash")
             .args(vec!["-c", shell_command.as_str()])
             .status()?
             .code()
-            .unwrap_or(-1))
+            .unwrap_or(-1);
+        if status != 0 {
+            return Err(Error::CommandFailed(status));
+        }
+        for output in self.outputs.iter() {
+            match std::fs::metadata(output) {
+                Ok(m) => m,
+                Err(e) if e.kind() == ErrorKind::NotFound => {
+                    return Err(Error::MissingOutput(output.clone()));
+                }
+                Err(e) => return Err(e.into()),
+            };
+        }
+        Ok(())
     }
 }
 
@@ -133,140 +163,4 @@ fn find_newest(path: &str) -> Result<File, Error> {
         }
     }
     Ok(newest)
-}
-
-#[cfg(test)]
-mod tests {
-    use std::time::Duration;
-
-    use tempfile::{tempdir, TempDir};
-
-    use super::*;
-
-    #[derive(Debug, Clone, Copy)]
-    enum InputCase {
-        None,
-        Old,
-        Equal,
-        New,
-    }
-
-    impl InputCase {
-        fn permute_time(&self, time: SystemTime) -> SystemTime {
-            match self {
-                InputCase::Old => time - Duration::from_secs(1),
-                InputCase::Equal | InputCase::None => time,
-                InputCase::New => time + Duration::from_secs(1),
-            }
-        }
-    }
-
-    #[derive(Debug, Clone, Copy)]
-    enum OutputCase {
-        None,
-        Missing,
-        Some,
-    }
-
-    fn all_test_cases() -> Vec<(InputCase, OutputCase)> {
-        let input_cases = [
-            InputCase::None,
-            InputCase::Old,
-            InputCase::Equal,
-            InputCase::New,
-        ];
-        let output_cases = [OutputCase::None, OutputCase::Missing, OutputCase::Some];
-
-        input_cases
-            .into_iter()
-            .flat_map(|ic| output_cases.map(|oc| (ic, oc)))
-            .collect()
-    }
-
-    fn setup_test_case(tempdir: &TempDir, ic: InputCase, oc: OutputCase) -> Vec<String> {
-        let now = SystemTime::now() - Duration::from_secs(60); // Back in time so avoid flaky tests
-        let mut args = vec![];
-
-        // Setup the output...
-        let output_path = tempdir
-            .path()
-            .join("output-file")
-            .to_str()
-            .unwrap()
-            .to_owned();
-
-        match oc {
-            OutputCase::None => (),
-            OutputCase::Missing => args.push(output_path.clone()),
-            OutputCase::Some => {
-                std::fs::File::create_new(&output_path)
-                    .unwrap()
-                    .set_modified(now)
-                    .unwrap();
-                args.push(output_path.clone());
-            }
-        }
-
-        // Setup the input...
-        args.push(":".into());
-        let input_path = tempdir
-            .path()
-            .join("input-file")
-            .to_str()
-            .unwrap()
-            .to_owned();
-
-        match ic {
-            InputCase::None => (),
-            ic @ _ => {
-                std::fs::File::create_new(&input_path)
-                    .unwrap()
-                    .set_modified(ic.permute_time(now))
-                    .unwrap();
-                args.push(input_path);
-            }
-        }
-
-        args.push("--".into());
-        args.push("touch".into());
-        args.push(output_path.into());
-
-        args
-    }
-
-    fn check_build(args: &Vec<String>, expected_needs_build: bool) {
-        let target = Target::parse(args.clone()).unwrap();
-        assert_eq!(target.needs_rebuild, expected_needs_build);
-        assert_eq!(target.should_run_command(), expected_needs_build);
-
-        let expected_code = 0;
-        let actual_code = target.run_command().unwrap();
-        assert_eq!(actual_code, expected_code);
-    }
-
-    #[tracing_test::traced_test]
-    #[test]
-    fn test_needs_rebuild() {
-        for case in all_test_cases() {
-            let tempdir = tempdir().unwrap();
-            let args = setup_test_case(&tempdir, case.0, case.1);
-
-            let expected_needs_build = match case {
-                (_, OutputCase::None | OutputCase::Missing) => true,
-                (InputCase::None, _) => true,
-                (InputCase::New, OutputCase::Some) => true,
-                (InputCase::Old | InputCase::Equal, OutputCase::Some) => false,
-            };
-            check_build(&args, expected_needs_build);
-
-            let expected_needs_rebuild = match case {
-                (_, OutputCase::None) => true,
-                (InputCase::None, _) => true,
-                (_, OutputCase::Missing) => false, // We built, so no rebuild
-                (InputCase::New, OutputCase::Some) => false, // We built, so no rebuild
-                (InputCase::Old | InputCase::Equal, OutputCase::Some) => false, // No build, so no rebuild
-            };
-            check_build(&args, expected_needs_rebuild);
-        }
-    }
 }


### PR DESCRIPTION
This required quite a big refactoring, and I also rewrote the tests to be much more straightforward, using assert_cmd to black box test the tool.